### PR TITLE
Change role and user names comparison to case-insensitive

### DIFF
--- a/role-writer.js
+++ b/role-writer.js
@@ -202,9 +202,9 @@ var sync = function (config, iam, wanted, gotMapped, scopeChecker) {
     var syncOps = SyncEngine.sync(
         wanted.RoleDetailList,
         gotMapped.RoleDetailList,
-        function (e) { return e.RoleName; },
+        function (e) { return e.RoleName.toUpperCase(); },
         function (w, g) {
-            return w.RoleName === g.RoleName &&
+            return w.RoleName.toUpperCase() === g.RoleName.toUpperCase() &&
                 w.Path === g.Path &&
                 deepEqual(w.AssumeRolePolicyDocument, g.AssumeRolePolicyDocument) &&
                 deepEqual(

--- a/user-writer.js
+++ b/user-writer.js
@@ -294,9 +294,9 @@ var sync = function (config, iam, wanted, gotMapped, scopeChecker) {
     var syncOps = SyncEngine.sync(
         wanted.UserDetailList,
         gotMapped.UserDetailList,
-        function (e) { return e.UserName; },
+        function (e) { return e.UserName.toUpperCase(); },
         function (w, g) {
-            return w.UserName === g.UserName &&
+            return w.UserName.toUpperCase() === g.UserName.toUpperCase() &&
                 w.Path === g.Path &&
                 deepEqual(
                     w.GroupList.sort(),


### PR DESCRIPTION
AWS does not look at the case for the role name where as locally this is considered. This causes errors which can cause a create and delete when it should not be done.
